### PR TITLE
Bumped dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,11 @@ packages = find:
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    pyobjc-framework-LocalAuthentication >= 6.2.2; platform_system=='Darwin'
-    winrt >= 1.0.20330.1; platform_system == 'Windows' and python_version >= '3.7' and python_version <= '3.9'
-    cryptography >= 3.1.1
-    keyring >= 21.4.0
-    fido2 >= 0.8.1
+    pyobjc-framework-LocalAuthentication >= 7.1; platform_system=='Darwin'
+    winrt >= 1.0.20330.1; platform_system == 'Windows' and python_version >= '3.7'
+    cryptography >= 3.4.6
+    keyring >= 22.3.0
+    fido2 >= 0.9.1
 setup_requires = setuptools_scm >= 4.1.2
 
 [options.packages.find]

--- a/tests/test_ctap_keyring_device.py
+++ b/tests/test_ctap_keyring_device.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 from uuid import uuid4
 
 import keyring
-from fido2 import ctap2, webauthn, cose, cbor
+from fido2 import ctap2, webauthn, cose, cbor, hid
 from fido2.attestation import PackedAttestation
 from fido2.client import ClientData, WEBAUTHN_TYPE
 from fido2.ctap import CtapError
@@ -55,7 +55,7 @@ class TestCtapKeyringDevice(unittest.TestCase):
         keyring.set_keyring(self._keyring)
 
     def test_capabilities_include_cbor(self):
-        assert self._dev.capabilities & ctap2.CAPABILITY.CBOR
+        assert self._dev.capabilities & hid.CAPABILITY.CBOR
 
     def test_info(self):
         info = self._dev.get_info()
@@ -266,21 +266,21 @@ class TestCtapKeyringDevice(unittest.TestCase):
 
     def test_failure_on_unsupported_ctap_cmd(self):
         res = self._dev.call(
-            CTAPHID.CBOR, data=ctap2.CTAP2.CMD.CLIENT_PIN.to_bytes(1, 'big')
+            CTAPHID.CBOR, data=ctap2.Ctap2.CMD.CLIENT_PIN.to_bytes(1, 'big')
         )
         assert res == CtapError.ERR.INVALID_COMMAND.to_bytes(1, 'big')
 
     def test_failure_on_malformed_cbor_data(self):
         res = self._dev.call(
             CTAPHID.CBOR,
-            data=ctap2.CTAP2.CMD.MAKE_CREDENTIAL.to_bytes(1, 'big') + b'malformed',
+            data=ctap2.Ctap2.CMD.MAKE_CREDENTIAL.to_bytes(1, 'big') + b'malformed',
         )
         assert res == CtapError.ERR.INVALID_CBOR.to_bytes(1, 'big')
 
     def test_failure_on_non_dict_cbor_data(self):
         res = self._dev.call(
             CTAPHID.CBOR,
-            data=ctap2.CTAP2.CMD.MAKE_CREDENTIAL.to_bytes(1, 'big')
+            data=ctap2.Ctap2.CMD.MAKE_CREDENTIAL.to_bytes(1, 'big')
             + cbor.encode('str'),
         )
         assert res == CtapError.ERR.INVALID_CBOR.to_bytes(1, 'big')


### PR DESCRIPTION
Note: Will now return a more complete get assertion response,
consisting of both a valid user handle, and a credential object (not
just its ID).

This is more compliant with the fido RFC & aligned w/ the chromium
implementation.
