### PR TITLE
Upgrade to fido2 1.0.0, add support for Python 3.10 by migrating winrt -> winsdk

### DIFF
--- a/.github/workflows/CD-pre-release.yml
+++ b/.github/workflows/CD-pre-release.yml
@@ -17,10 +17,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -17,10 +17,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 default_language_version:
-  python: python3.6
+  python: python3.7
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -13,6 +13,6 @@ repos:
       - id: trailing-whitespace
       - id: fix-encoding-pragma
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.12b0
     hooks:
       - id: black

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
+  version: '3.8'
   install:
   - requirements: docs/requirements.txt

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+2.0
+====
+This release contains breaking changes for dependents on fido2 <= v1.0.0:
+- Bumped min Python version from 3.6 to 3.7
+- Upgraded to fido2 v1.0.0, which had numerous breaking changes
+- Migrated from winrt to winsdk to support Python 3.10
+
 1.0
 ===
 

--- a/ctap_keyring_device/ctap_credential_maker.py
+++ b/ctap_keyring_device/ctap_credential_maker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Type
+from typing import Type, Union
 from uuid import uuid4, uuid5, NAMESPACE_OID
 
 from fido2.cose import CoseKey
@@ -9,12 +9,12 @@ from ctap_keyring_device.ctap_strucs import Credential
 
 
 class CtapCredentialMaker:
-    """ This class makes a new credential (key-pair) from the given COSE key type """
+    """This class makes a new credential (key-pair) from the given COSE key type"""
 
     def __init__(self, cose_key_cls: Type[CoseKey]):
         self._cose_key_cls = cose_key_cls
 
-    def make_credential(self, user_id: str) -> Credential:
+    def make_credential(self, user_id: Union[str, bytes]) -> Credential:
         """
         Generates a new credential, with a 32-byte id consisting of:
         - uuid5(NAMESPACE_OID, user_id)
@@ -24,6 +24,9 @@ class CtapCredentialMaker:
         :return: A new credential holding a generated private key
         """
         assert user_id
+
+        if isinstance(user_id, bytes):
+            user_id = user_id.decode('utf-8')
 
         private_key = CtapPrivateKeyWrapper.create(self._cose_key_cls)
         key_password = uuid4().bytes

--- a/ctap_keyring_device/ctap_private_key_wrapper.py
+++ b/ctap_keyring_device/ctap_private_key_wrapper.py
@@ -18,18 +18,18 @@ class CtapPrivateKeyWrapper(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_key(self):
-        """ Returns the wrapped private key """
+        """Returns the wrapped private key"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     def sign(self, data: bytes) -> bytes:
-        """ Signs the given data according to the algorithm """
+        """Signs the given data according to the algorithm"""
         raise NotImplementedError()
 
     @classmethod
     @abc.abstractmethod
     def get_algorithm(cls) -> int:
-        """ One of COSE defined algorithms, see https://www.iana.org/assignments/cose/cose.xhtml """
+        """One of COSE defined algorithms, see https://www.iana.org/assignments/cose/cose.xhtml"""
         raise NotImplementedError()
 
     def get_public_key(self):
@@ -63,7 +63,7 @@ class CtapPrivateKeyWrapper(metaclass=abc.ABCMeta):
 
 
 class CtapEs256PrivateKeyWrapper(CtapPrivateKeyWrapper):
-    """ ES256 (ECDSA w/ SHA-256) """
+    """ES256 (ECDSA w/ SHA-256)"""
 
     def __init__(self, key: ec.EllipticCurvePrivateKey = None):
         self._key = key or ec.generate_private_key(curve=ec.SECP256R1())
@@ -90,7 +90,7 @@ class CtapRsaPrivateKeyWrapper(CtapPrivateKeyWrapper, metaclass=abc.ABCMeta):
 
 
 class CtapRs256KeyGeneratorSigner(CtapRsaPrivateKeyWrapper):
-    """ RS256 (RSASSA-PKCS1-v1_5 w/ SHA-256) """
+    """RS256 (RSASSA-PKCS1-v1_5 w/ SHA-256)"""
 
     def sign(self, data: bytes) -> bytes:
         return self._key.sign(data, padding.PKCS1v15(), hashes.SHA256())
@@ -101,7 +101,7 @@ class CtapRs256KeyGeneratorSigner(CtapRsaPrivateKeyWrapper):
 
 
 class CtapRs1PrivateKeyWrapper(CtapRsaPrivateKeyWrapper):
-    """ RS1 (RSASSA-PKCS1-v1_5 w/ SHA-1) """
+    """RS1 (RSASSA-PKCS1-v1_5 w/ SHA-1)"""
 
     def sign(self, data: bytes) -> bytes:
         return self._key.sign(data, padding.PKCS1v15(), hashes.SHA1())
@@ -112,7 +112,7 @@ class CtapRs1PrivateKeyWrapper(CtapRsaPrivateKeyWrapper):
 
 
 class CtapPs256PrivateKeyWrapper(CtapRsaPrivateKeyWrapper):
-    """ PS256 (RSASSA-PSS w/ SHA-256) """
+    """PS256 (RSASSA-PSS w/ SHA-256)"""
 
     def sign(self, data: bytes) -> bytes:
         return self._key.sign(
@@ -129,7 +129,7 @@ class CtapPs256PrivateKeyWrapper(CtapRsaPrivateKeyWrapper):
 
 
 class CtapEdDsaPrivateKeyWrapper(CtapPrivateKeyWrapper):
-    """ EDDSA (Edwards-Curve DSA) """
+    """EDDSA (Edwards-Curve DSA)"""
 
     def __init__(self, key: Ed25519PrivateKey = None):
         self._key = key or ed25519.Ed25519PrivateKey.generate()

--- a/ctap_keyring_device/ctap_strucs.py
+++ b/ctap_keyring_device/ctap_strucs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+from timeit import default_timer as timer
 from typing import List
 
 from cryptography.hazmat.primitives import serialization
@@ -14,8 +15,6 @@ from fido2.webauthn import (
 
 from ctap_keyring_device.ctap_private_key_wrapper import CtapPrivateKeyWrapper
 
-from timeit import default_timer as timer
-
 
 class CtapOptions:
     PLATFORM_DEVICE = 'plat'
@@ -26,7 +25,7 @@ class CtapOptions:
 
 
 class Credential:
-    """ Represents a ctap-saved credential - with a credential id, private key, and a COSE algorithm. """
+    """Represents a ctap-saved credential - with a credential id, private key, and a COSE algorithm."""
 
     def __init__(self, credential_id: bytes, private_key: CtapPrivateKeyWrapper):
         self.id = credential_id
@@ -72,7 +71,7 @@ class Credential:
 
 
 class CtapMakeCredentialRequest:
-    """ Represents the cbor encoded MAKE_CREDENTIAL request """
+    """Represents the cbor encoded MAKE_CREDENTIAL request"""
 
     CLIENT_DATA_HASH_KEY = 1
     RP_KEY = 2
@@ -119,16 +118,16 @@ class CtapMakeCredentialRequest:
         # noinspection PyProtectedMember
         return CtapMakeCredentialRequest(
             client_data_hash=make_credential_request.get(cls.CLIENT_DATA_HASH_KEY),
-            rp=PublicKeyCredentialRpEntity._wrap(
+            rp=PublicKeyCredentialRpEntity.from_dict(
                 make_credential_request.get(cls.RP_KEY)
             ),
-            user=PublicKeyCredentialUserEntity._wrap(
-                make_credential_request.get(cls.USER_KEY)
+            user=PublicKeyCredentialUserEntity.from_dict(
+                make_credential_request.get(cls.USER_KEY),
             ),
-            public_key_credential_params=PublicKeyCredentialParameters._wrap_list(
+            public_key_credential_params=PublicKeyCredentialParameters._deserialize_list(
                 make_credential_request.get(cls.PUBLIC_KEY_CREDENTIAL_PARAMS_KEY)
             ),
-            exclude_list=PublicKeyCredentialDescriptor._wrap_list(
+            exclude_list=PublicKeyCredentialDescriptor._deserialize_list(
                 make_credential_request.get(cls.EXCLUDE_LIST_KEY)
             ),
             extensions=make_credential_request.get(cls.EXTENSIONS_KEY),
@@ -139,7 +138,7 @@ class CtapMakeCredentialRequest:
 
 
 class CtapGetAssertionRequest:
-    """ Represents the cbor encoded GET_ASSERTION request """
+    """Represents the cbor encoded GET_ASSERTION request"""
 
     RP_ID_KEY = 1
     CLIENT_DATA_HASH_KEY = 2
@@ -178,7 +177,7 @@ class CtapGetAssertionRequest:
         return CtapGetAssertionRequest(
             rp_id=get_assertion_req.get(cls.RP_ID_KEY),
             client_data_hash=get_assertion_req.get(cls.CLIENT_DATA_HASH_KEY),
-            allow_list=PublicKeyCredentialDescriptor._wrap_list(
+            allow_list=PublicKeyCredentialDescriptor._deserialize_list(
                 get_assertion_req.get(cls.ALLOW_LIST_KEY)
             ),
             extensions=get_assertion_req.get(cls.EXTENSIONS_KEY),

--- a/ctap_keyring_device/user_verifiers/ctap_user_verifier.py
+++ b/ctap_keyring_device/user_verifiers/ctap_user_verifier.py
@@ -27,12 +27,12 @@ class CtapUserVerifier(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def available(self) -> bool:
-        """ If set, this verifier is available on the current OS """
+        """If set, this verifier is available on the current OS"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     def verify_user(self, rp_id: str) -> bool:
-        """ Returns true if the user was successfully verified """
+        """Returns true if the user was successfully verified"""
         raise NotImplementedError()
 
 

--- a/ctap_keyring_device/user_verifiers/noop_ctap_user_verifier.py
+++ b/ctap_keyring_device/user_verifiers/noop_ctap_user_verifier.py
@@ -3,7 +3,7 @@ from ctap_keyring_device.user_verifiers.ctap_user_verifier import CtapUserVerifi
 
 
 class NoopCtapUserVerifier(CtapUserVerifierBase):
-    """ Dummy verifier - always returns true """
+    """Dummy verifier - always returns true"""
 
     def _available(self) -> bool:
         return True

--- a/ctap_keyring_device/user_verifiers/touch_id_ctap_user_verifier.py
+++ b/ctap_keyring_device/user_verifiers/touch_id_ctap_user_verifier.py
@@ -12,7 +12,7 @@ from ctap_keyring_device.user_verifiers.ctap_user_verifier import CtapUserVerifi
 
 
 class TouchIdCtapUserVerifier(CtapUserVerifierBase):
-    """ A Touch ID based CTAP User Verifier - Prompts for the user's login password / fingerprint """
+    """A Touch ID based CTAP User Verifier - Prompts for the user's login password / fingerprint"""
 
     LA_POLICY = LAPolicyDeviceOwnerAuthentication
 

--- a/ctap_keyring_device/user_verifiers/windows_hello_ctap_user_verifier.py
+++ b/ctap_keyring_device/user_verifiers/windows_hello_ctap_user_verifier.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
 # noinspection PyUnresolvedReferences
-import winrt.windows.security.credentials.ui as ui
+import winsdk.windows.security.credentials.ui as ui
 import asyncio
 
 from ctap_keyring_device.user_verifiers.ctap_user_verifier import CtapUserVerifierBase
 
 
 class WindowsHelloCtapUserVerifier(CtapUserVerifierBase):
-    """ A Windows Hello based CTAP User verifier; Prompts for a PIN / fingerprint """
+    """A Windows Hello based CTAP User verifier; Prompts for a PIN / fingerprint"""
 
     def __init__(self):
         self._event_loop = asyncio.get_event_loop()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ autodoc_mock_imports = [
     'Security',
     'LocalAuthentication',
     'cbor',
-    'winrt',
+    'winsdk',
 ]
 
 link_files = {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs = dist build .tox .eggs
-addopts = --flake8 --black --cov
+addopts = --black --cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,13 +18,13 @@ classifiers =
 [options]
 packages = find:
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     pyobjc-framework-LocalAuthentication >= 7.1; platform_system=='Darwin'
-    winrt >= 1.0.20330.1; platform_system == 'Windows' and python_version >= '3.7'
+    winsdk >= 1.0.0b6; platform_system == 'Windows' and python_version >= '3.7'
     cryptography >= 3.4.6
     keyring >= 23.0.0
-    fido2 >= 0.9.1
+    fido2 >= 1.0.0
 setup_requires = setuptools_scm >= 4.1.2
 
 [options.packages.find]
@@ -33,7 +33,6 @@ exclude = tests
 [options.extras_require]
 testing =
     pytest >= 6.0.1
-    pytest-flake8 >= 1.0.6
     pytest-black >= 0.3.11
     pytest-cov >= 2.10.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,24 @@
 [tox]
-envlist = py{36,37,38,39}-{darwin,linux,win32}
-minversion = 3.20.0
+envlist = py{37,38,39,310}-{darwin,linux,win32}
+minversion = 3.25.1
 requires =
     tox-pip-version>=0.0.7
     tox-pyenv>=1.1.0
-    tox-gh-actions>=1.3.0
+    tox-gh-actions>=2.9.1
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, docs, build, release
+    3.9: py39
+    3.10: py310, docs, build, release
 
 [testenv]
 platform =
     darwin: darwin
     linux: linux
     win32: win32
-pip_version = pip>=20.2.3
+pip_version = pip>=22.2.2
 commands = pytest {posargs}
 usedevelop = True
 extras = testing
@@ -40,8 +40,8 @@ platform =
     win32: win32
 skip_install = True
 deps =
-    pep517>=0.8.2
-    path>=15.0.0
+    pep517>=0.13.0
+    path>=16.4.0
 commands =
     python -c "import path; path.Path('dist').rmtree_p()"
     python -m pep517.build .
@@ -53,7 +53,7 @@ platform =
     win32: win32
 skip_install = True
 deps =
-    twine>=3.2.0
+    twine>=4.0.1
     {[testenv:build]deps}
 passenv = TWINE_PASSWORD
 setenv = TWINE_USERNAME = {env:TWINE_USERNAME:__token__}


### PR DESCRIPTION
This commit:
- Upgrades to fido2 1.0.0, which had several breaking changes which were dealt with
- Adds support for python 3.10 by moving from the unmaintained winrt to the community maintained winsdk
- Bumps several dependencies to a later version
- Drops pytest-flake8, as it's currently broken (see: https://github.com/tholo/pytest-flake8/issues/87)
- Bumps the min. supported Python version to 3.7