### PR TITLE
Fix algorithms for ctap_keyring_device.

### DIFF
--- a/ctap_keyring_device/ctap_keyring_device.py
+++ b/ctap_keyring_device/ctap_keyring_device.py
@@ -79,6 +79,10 @@ class CtapKeyringDevice(ctap.CtapDevice):
             ctap2.Ctap2.CMD.GET_INFO: self.get_info,
         }
 
+        algorithms = []
+        for i in cose.CoseKey.supported_algorithms():
+            algorithms.append({'type': 'public-key', 'alg': i})
+
         self._info = Info(
             versions=self.SUPPORTED_CTAP_VERSIONS,
             extensions=[],
@@ -93,7 +97,7 @@ class CtapKeyringDevice(ctap.CtapDevice):
             pin_uv_protocols=[ctap2.PinProtocolV2.VERSION],
             max_msg_size=self.MAX_MSG_SIZE,
             transports=[webauthn.AuthenticatorTransport.INTERNAL],
-            algorithms=cose.CoseKey.supported_algorithms(),
+            algorithms=algorithms,
         )
 
         self._next_assertions_ctx: Optional[CtapGetNextAssertionContext] = None


### PR DESCRIPTION
Specifically, the algorithms argument to Info has changed in newer versions of python-fido2, it is now an array of maps instead of an array of ints.

Naturally, cose.CoseKey.supported_algorithms() still just returns an array of ints.

This change makes CtapKeyringDevice.__init__ work again.